### PR TITLE
Typo in recommended pinning

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -90,7 +90,7 @@ version:
 
 .. code:: console
 
-    $ pip install "sphinx_rtd_theme<=2.0.0"
+    $ pip install "sphinx_rtd_theme<2.0"
 
 .. _semantic versioning: http://semver.org/
 


### PR DESCRIPTION
The paragraph above recommends "less than the next major version". But the example says `<=`. Make them match